### PR TITLE
Fix non-privileged port range in modbus tests

### DIFF
--- a/tests/test_live_modbus.py
+++ b/tests/test_live_modbus.py
@@ -27,7 +27,7 @@ async def test_live_modbus_connection(hass: HomeAssistant, mock_registers):
     register_name, register_data = mock_registers
 
     # Use non-privileged port for testing
-    test_port = random.randint(1000, 50000)
+    test_port = random.randint(1024, 50000)
     server_task = asyncio.create_task(run_server("127.0.0.1", test_port, register_data))
 
     # Wait for server to start


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Adjusted the test configuration to ensure that generated port numbers start above reserved ranges, improving the reliability and safety of testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->