### PR TITLE
Limit to pymodbus>=3.8.2,<3.8.5

### DIFF
--- a/custom_components/komfovent/manifest.json
+++ b/custom_components/komfovent/manifest.json
@@ -13,7 +13,7 @@
     "pymodbus"
   ],
   "requirements": [
-    "pymodbus>=3.8.3,<4.0"
+    "pymodbus>=3.8.2,<3.8.5"
   ],
   "version": "0.6.1"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorlog==6.9.0
 homeassistant==2025.3.1
 pip>=21.3.1
-pymodbus>=3.8.3,<4.0
+pymodbus>=3.8.2,<3.8.5
 ruff==0.11.5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated dependency requirements to restrict the accepted version range for the `pymodbus` package to a narrower subset within the 3.8.x series.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->