### PR TITLE
Update pymodbus requirement to support version 3.9.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorlog==6.9.0
 homeassistant==2025.3.1
 pip>=21.3.1
-pymodbus>=3.8.2,<3.8.5
+pymodbus>=3.8.2,<3.10
 ruff==0.12.8


### PR DESCRIPTION
Update pymodbus requirement to <3.10 for compatibility with HA 2025.8.2 (`pymodbus==3.9.2`).

Fixes #92 