### PR TITLE
Use SensorDeviceClass.ABSOLUTE_HUMIDITY

### DIFF
--- a/custom_components/komfovent/sensor.py
+++ b/custom_components/komfovent/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.const import (
+    CONCENTRATION_GRAMS_PER_CUBIC_METER,
     CONCENTRATION_PARTS_PER_MILLION,
     PERCENTAGE,
     UnitOfEnergy,
@@ -555,7 +556,8 @@ async def create_sensors(coordinator: KomfoventCoordinator) -> list[KomfoventSen
                     entity_description=SensorEntityDescription(
                         key="indoor_absolute_humidity",
                         name="Indoor Absolute Humidity",
-                        native_unit_of_measurement="g/m³",
+                        native_unit_of_measurement=CONCENTRATION_GRAMS_PER_CUBIC_METER,
+                        device_class=SensorDeviceClass.ABSOLUTE_HUMIDITY,
                         state_class=SensorStateClass.MEASUREMENT,
                         suggested_display_precision=2,
                     ),
@@ -574,7 +576,8 @@ async def create_sensors(coordinator: KomfoventCoordinator) -> list[KomfoventSen
                     entity_description=SensorEntityDescription(
                         key="outdoor_absolute_humidity",
                         name="Outdoor Absolute Humidity",
-                        native_unit_of_measurement="g/m³",
+                        native_unit_of_measurement=CONCENTRATION_GRAMS_PER_CUBIC_METER,
+                        device_class=SensorDeviceClass.ABSOLUTE_HUMIDITY,
                         state_class=SensorStateClass.MEASUREMENT,
                         suggested_display_precision=2,
                     ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized indoor and outdoor Absolute Humidity sensors to use Home Assistant’s native concentration unit, ensuring consistent unit display across the UI and integrations.
  - Assigned the Absolute Humidity device class to both sensors for improved categorization, icons, and compatibility with dashboards, history charts, and automations.
  - Enhances overall UX by aligning sensor metadata with Home Assistant conventions, reducing confusion from custom units and improving interoperability with templates and third-party components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->