### PR TITLE
Updates for the new pymodbus 3.12 brought with the HA release 2025.09

### DIFF
--- a/custom_components/komfovent/diagnostics.py
+++ b/custom_components/komfovent/diagnostics.py
@@ -104,7 +104,7 @@ async def dump_registers(host: str, port: int) -> dict[int, list[int]]:
             try:
                 # try to read the whole block
                 response = await client.read_holding_registers(
-                    address=start - 1, count=count
+                    address=start - 1, count=count, device_id=1
                 )
                 _check_response(response)
 
@@ -123,14 +123,14 @@ async def dump_registers(host: str, port: int) -> dict[int, list[int]]:
                         if reg in REGISTERS_32BIT_UNSIGNED:
                             # read 2 registers for 32-bit unsigned values
                             response = await client.read_holding_registers(
-                                address=reg - 1, count=2
+                                address=reg - 1, count=2, device_id=1
                             )
                             attempted.add(reg)
                             attempted.add(reg + 1)
                         else:
                             # read 1 register for other values
                             response = await client.read_holding_registers(
-                                address=reg - 1, count=1
+                                address=reg - 1, count=1, device_id=1
                             )
                             attempted.add(reg)
                         _check_response(response)

--- a/custom_components/komfovent/manifest.json
+++ b/custom_components/komfovent/manifest.json
@@ -13,7 +13,7 @@
     "pymodbus"
   ],
   "requirements": [
-    "pymodbus>=3.9.2,<3.10.0"
+    "pymodbus>=3.9.2,<3.12.0"
   ],
   "version": "0.7.0"
 }

--- a/custom_components/komfovent/modbus.py
+++ b/custom_components/komfovent/modbus.py
@@ -42,7 +42,7 @@ class KomfoventModbusClient:
         """Read holding registers and return dict keyed by absolute register numbers."""
         async with self._lock:
             result = await self.client.read_holding_registers(
-                address=register - 1, count=count, slave=1
+                address=register - 1, count=count, device_id=1
             )
 
         if result.isError():
@@ -86,12 +86,12 @@ class KomfoventModbusClient:
         async with self._lock:
             if register in REGISTERS_16BIT_UNSIGNED:
                 # Write unsigned value as-is
-                result = await self.client.write_register(register - 1, value, slave=1)
+                result = await self.client.write_register(register - 1, value, device_id=1)
             elif register in REGISTERS_16BIT_SIGNED:
                 # Convert signed value to 16-bit unsigned for Modbus
                 unsigned_value = value & 0xFFFF
                 result = await self.client.write_register(
-                    register - 1, unsigned_value, slave=1
+                    register - 1, unsigned_value, device_id=1
                 )
             elif register in REGISTERS_32BIT_UNSIGNED:
                 # Split 32-bit value into two 16-bit values
@@ -100,7 +100,7 @@ class KomfoventModbusClient:
 
                 # Write both words in a single transaction
                 result = await self.client.write_registers(
-                    address=register - 1, values=[high_word, low_word], slave=1
+                    address=register - 1, values=[high_word, low_word], device_id=1
                 )
             else:
                 msg = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorlog==6.9.0
 homeassistant==2025.8.1
 pip>=21.3.1
-pymodbus>=3.9.2,<3.10.0
+pymodbus>=3.9.2,<3.12.0
 ruff==0.12.9


### PR DESCRIPTION
This pull implements suggestions by MaBeniu in issue https://github.com/lnagel/hass-komfovent/issues/101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures all Modbus reads and writes consistently target the correct device address, improving communication reliability and diagnostics accuracy.

* **Chores**
  * Expanded supported pymodbus versions to include 3.10.x and 3.11.x (up to but not including 3.12.0) for broader compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->