### PR TITLE
Upgrade to homeassistant==2025.9.1 pymodbus==3.10.0

### DIFF
--- a/custom_components/komfovent/manifest.json
+++ b/custom_components/komfovent/manifest.json
@@ -13,7 +13,7 @@
     "pymodbus"
   ],
   "requirements": [
-    "pymodbus>=3.9.2,<3.10.0"
+    "pymodbus>=3.10.0,<3.11.0"
   ],
   "version": "0.7.0"
 }

--- a/custom_components/komfovent/modbus.py
+++ b/custom_components/komfovent/modbus.py
@@ -42,7 +42,7 @@ class KomfoventModbusClient:
         """Read holding registers and return dict keyed by absolute register numbers."""
         async with self._lock:
             result = await self.client.read_holding_registers(
-                address=register - 1, count=count, slave=1
+                address=register - 1, count=count
             )
 
         if result.isError():
@@ -86,13 +86,11 @@ class KomfoventModbusClient:
         async with self._lock:
             if register in REGISTERS_16BIT_UNSIGNED:
                 # Write unsigned value as-is
-                result = await self.client.write_register(register - 1, value, slave=1)
+                result = await self.client.write_register(register - 1, value)
             elif register in REGISTERS_16BIT_SIGNED:
                 # Convert signed value to 16-bit unsigned for Modbus
                 unsigned_value = value & 0xFFFF
-                result = await self.client.write_register(
-                    register - 1, unsigned_value, slave=1
-                )
+                result = await self.client.write_register(register - 1, unsigned_value)
             elif register in REGISTERS_32BIT_UNSIGNED:
                 # Split 32-bit value into two 16-bit values
                 high_word = (value >> 16) & 0xFFFF
@@ -100,7 +98,7 @@ class KomfoventModbusClient:
 
                 # Write both words in a single transaction
                 result = await self.client.write_registers(
-                    address=register - 1, values=[high_word, low_word], slave=1
+                    address=register - 1, values=[high_word, low_word]
                 )
             else:
                 msg = (

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
     "name": "Komfovent",
-    "homeassistant": "2025.8.1",
+    "homeassistant": "2025.9.1",
     "hacs": "2.0.1",
     "render_readme": true
 }

--- a/modbus_server.py
+++ b/modbus_server.py
@@ -8,13 +8,12 @@ import logging
 import sys
 from pathlib import Path
 
+from pymodbus import ModbusDeviceIdentification
 from pymodbus.datastore import (
-    ModbusSequentialDataBlock,
+    ModbusDeviceContext,
     ModbusServerContext,
-    ModbusSlaveContext,
     ModbusSparseDataBlock,
 )
-from pymodbus.device import ModbusDeviceIdentification
 from pymodbus.server import StartAsyncTcpServer
 
 # Configure logging
@@ -36,12 +35,9 @@ async def run_server(host: str, port: int, register_data: dict[str, [int]]) -> N
     block_values = {int(k): v for k, v in register_data.items()}
 
     # Initialize data storage
-    discrete_inputs = (
-        ModbusSequentialDataBlock.create()
-    )  # workaround for bug in pymodbus 3.9.x
     holding_registers = ModbusSparseDataBlock(block_values)
-    store = ModbusSlaveContext(di=discrete_inputs, hr=holding_registers)
-    context = ModbusServerContext(slaves=store, single=True)
+    store = ModbusDeviceContext(hr=holding_registers)
+    context = ModbusServerContext(devices=store, single=True)
 
     # Server identity
     identity = ModbusDeviceIdentification()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorlog==6.9.0
-homeassistant==2025.8.1
+homeassistant==2025.9.1
 pip>=21.3.1
-pymodbus>=3.9.2,<3.10.0
+pymodbus>=3.10.0,<3.11.0
 ruff==0.12.9

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,4 +2,4 @@
 pytest>=7.0.0
 pytest-asyncio>=0.20.0
 pytest-cov>=4.0.0
-pytest-homeassistant-custom-component==0.13.270
+pytest-homeassistant-custom-component==0.13.278


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - Improved Modbus communication reliability and compatibility with newer library versions.
- Refactor
  - Updated internal Modbus server context to a device-based model for increased stability.
- Chores
  - Bumped Home Assistant compatibility to 2025.9.1.
  - Updated Modbus library to 3.10.x.
  - Refreshed development/test dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->