### PR TITLE
Fix Komfovent services.yaml validation error

### DIFF
--- a/custom_components/komfovent/services.py
+++ b/custom_components/komfovent/services.py
@@ -108,29 +108,29 @@ async def async_register_services(hass: HomeAssistant) -> None:
 
     async def handle_clean_filters_calibration(call: ServiceCall) -> None:
         """Handle the clean filters calibration service call."""
-        for device_id in call.data["device_id"]:
-            if not (coordinator := get_coordinator_for_device(hass, device_id)):
-                _LOGGER.error("Device %s not found", device_id)
-                continue
-            await clean_filters_calibration(coordinator)
+        device_id = call.data["device_id"]
+        if not (coordinator := get_coordinator_for_device(hass, device_id)):
+            _LOGGER.error("Device %s not found", device_id)
+            return
+        await clean_filters_calibration(coordinator)
 
     async def handle_set_operation_mode(call: ServiceCall) -> None:
         """Handle the set operation mode service call."""
-        for device_id in call.data["device_id"]:
-            if not (coordinator := get_coordinator_for_device(hass, device_id)):
-                _LOGGER.error("Device %s not found", device_id)
-                continue
-            await set_operation_mode(
-                coordinator, call.data["mode"], call.data.get("minutes")
-            )
+        device_id = call.data["device_id"]
+        if not (coordinator := get_coordinator_for_device(hass, device_id)):
+            _LOGGER.error("Device %s not found", device_id)
+            return
+        await set_operation_mode(
+            coordinator, call.data["mode"], call.data.get("minutes")
+        )
 
     async def handle_set_system_time(call: ServiceCall) -> None:
         """Handle the set system time service call."""
-        for device_id in call.data["device_id"]:
-            if not (coordinator := get_coordinator_for_device(hass, device_id)):
-                _LOGGER.error("Device %s not found", device_id)
-                continue
-            await set_system_time(coordinator)
+        device_id = call.data["device_id"]
+        if not (coordinator := get_coordinator_for_device(hass, device_id)):
+            _LOGGER.error("Device %s not found", device_id)
+            return
+        await set_system_time(coordinator)
 
     hass.services.async_register(
         DOMAIN, "clean_filters_calibration", handle_clean_filters_calibration

--- a/custom_components/komfovent/services.yaml
+++ b/custom_components/komfovent/services.yaml
@@ -1,17 +1,26 @@
 clean_filters_calibration:
   name: Clean Filters Calibration
   description: Calibrate clean filters on the Komfovent unit
-  target:
-    device:
-      integration: komfovent
+  fields:
+    device_id:
+      name: Device
+      description: The Komfovent device to calibrate
+      required: true
+      selector:
+        device:
+          integration: komfovent
 
 set_operation_mode:
   name: Set Operation Mode
   description: Set the operation mode of the Komfovent unit
-  target:
-    device:
-      integration: komfovent
   fields:
+    device_id:
+      name: Device
+      description: The Komfovent device
+      required: true
+      selector:
+        device:
+          integration: komfovent
     mode:
       name: Mode
       description: The operation mode to set
@@ -41,6 +50,11 @@ set_operation_mode:
 set_system_time:
   name: Set System Time
   description: Set the system time on the Komfovent unit to match the local time
-  target:
-    device:
-      integration: komfovent
+  fields:
+    device_id:
+      name: Device
+      description: The Komfovent device
+      required: true
+      selector:
+        device:
+          integration: komfovent


### PR DESCRIPTION
Replace deprecated device filter on target with device selector in fields section, as required by new Hassfest validation rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Komfovent services now use `device_id` field instead of target-based device specification
  * Service calls now process a single device per invocation instead of multiple devices

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->