### PR TITLE
Change minimum update interval from 10 to 1 seconds

### DIFF
--- a/custom_components/komfovent/config_flow.py
+++ b/custom_components/komfovent/config_flow.py
@@ -46,7 +46,7 @@ OPTIONS_SCHEMA = vol.Schema(
             OPT_UPDATE_INTERVAL, default=DEFAULT_UPDATE_INTERVAL
         ): NumberSelector(
             NumberSelectorConfig(
-                min=10,
+                min=1,
                 max=300,
                 step=5,
                 mode=NumberSelectorMode.SLIDER,


### PR DESCRIPTION
Hello,

I've been using this plugin and it's super great! But I found 10 seconds to be to slow for my needs. Would you mind changing to minimum 1 second update interval for the configuration?