### PR TITLE
Apply Modbus conversions when loading test fixtures

### DIFF
--- a/custom_components/komfovent/modbus.py
+++ b/custom_components/komfovent/modbus.py
@@ -15,6 +15,39 @@ from .registers import (
 _LOGGER = logging.getLogger(__name__)
 
 
+def convert_register_block(block: dict[int, int]) -> dict[int, int]:
+    """Apply signed and 32-bit conversions to a raw uint16 register block."""
+    converted: set[int] = set()
+    data: dict[int, int] = {}
+
+    for reg, value in block.items():
+        if reg in REGISTERS_16BIT_UNSIGNED:
+            # For 16-bit unsigned registers, use value directly
+            converted.add(reg)
+            data[reg] = value
+        elif reg in REGISTERS_16BIT_SIGNED:
+            # For 16-bit signed registers, convert uint16 to int16
+            converted.add(reg)
+            data[reg] = value - (value >> 15 << 16)
+        elif reg in REGISTERS_32BIT_UNSIGNED:
+            # For 32-bit registers, combine with next register
+            if reg + 1 not in block:
+                msg = f"Register {reg + 1} value not retrieved"
+                raise ValueError(msg)
+            converted.add(reg)
+            converted.add(reg + 1)
+            data[reg] = (value << 16) + block[reg + 1]
+
+    if not_converted := set(block.keys()) - converted:
+        msg = (
+            f"Registers {not_converted} not found in either "
+            "16-bit or 32-bit register sets"
+        )
+        raise NotImplementedError(msg)
+
+    return data
+
+
 class KomfoventModbusClient:
     """Modbus client for Komfovent devices."""
 
@@ -49,37 +82,8 @@ class KomfoventModbusClient:
             msg = f"Error reading registers at {register}"
             raise ModbusException(msg)
 
-        # Create dictionary with absolute register numbers as keys
         block = dict(enumerate(result.registers, start=register))
-        converted = set()
-        data = {}
-
-        for reg, value in block.items():
-            if reg in REGISTERS_16BIT_UNSIGNED:
-                # For 16-bit unsigned registers, use value directly
-                converted.add(reg)
-                data[reg] = value
-            elif reg in REGISTERS_16BIT_SIGNED:
-                # For 16-bit signed registers, use need to convert uint16 to int16
-                converted.add(reg)
-                data[reg] = value - (value >> 15 << 16)
-            elif reg in REGISTERS_32BIT_UNSIGNED:
-                # For 32-bit registers, combine with next register
-                if reg + 1 not in block:
-                    msg = f"Register {reg + 1} value not retrieved"
-                    raise ValueError(msg)
-                converted.add(reg)
-                converted.add(reg + 1)
-                data[reg] = (value << 16) + block[reg + 1]
-
-        if not_converted := set(block.keys()) - converted:
-            msg = (
-                f"Registers {not_converted} not found in either "
-                "16-bit or 32-bit register sets"
-            )
-            raise NotImplementedError(msg)
-
-        return data
+        return convert_register_block(block)
 
     async def write(self, register: int, value: int) -> None:
         """Write to holding register."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,13 +9,31 @@ from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.komfovent.const import DOMAIN, Controller
+from custom_components.komfovent.modbus import convert_register_block
+from custom_components.komfovent.registers import (
+    REGISTERS_16BIT_SIGNED,
+    REGISTERS_16BIT_UNSIGNED,
+    REGISTERS_32BIT_UNSIGNED,
+)
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
+_CLASSIFIED_REGISTERS = (
+    REGISTERS_16BIT_UNSIGNED
+    | REGISTERS_16BIT_SIGNED
+    | REGISTERS_32BIT_UNSIGNED
+    # high-word slots needed by convert_register_block for 32-bit combine
+    | {reg + 1 for reg in REGISTERS_32BIT_UNSIGNED}
+)
 
 
 def load_register_fixture(fixture_name: str) -> dict[int, int]:
     """
     Load a JSON fixture file and transform to register dict format.
+
+    Fixture files store raw uint16 wire data as exported by the
+    diagnostics dump. Production stores the post-conversion view
+    (signed temps, combined 32-bit values), so we apply the same
+    conversion here to match.
 
     Args:
         fixture_name: Name of the fixture file (e.g., "C6_registers_0.json")
@@ -28,11 +46,13 @@ def load_register_fixture(fixture_name: str) -> dict[int, int]:
     with json_path.open() as f:
         register_data = json.load(f)
 
-    return {
+    raw = {
         reg: value
         for block_start, values in register_data.items()
         for reg, value in enumerate(values, start=int(block_start))
+        if reg in _CLASSIFIED_REGISTERS
     }
+    return convert_register_block(raw)
 
 
 def get_controller_from_fixture_name(fixture_name: str) -> Controller:
@@ -161,22 +181,17 @@ def mock_modbus_client() -> MagicMock:
     mock_client.connect = AsyncMock(return_value=True)
     mock_client.close = AsyncMock()
 
-    json_file = Path(__file__).parent / Path("fixtures/C6_registers_0.json")
+    transformed_data = load_register_fixture("C6_registers_0.json")
 
-    with json_file.open() as f:
-        register_data = json.load(f)
-        transformed_data = {
-            reg: value
-            for block_start, values in register_data.items()
-            for reg, value in enumerate(values, start=int(block_start))
-        }
-
-    # Set up read to return data from our fixture
+    # Set up read to return data from our fixture, mirroring
+    # KomfoventModbusClient.read which only returns converted registers
+    # within the requested window.
     async def mock_read(register: int, count: int) -> dict[int, int]:
-        result = {}
-        for reg in range(register, register + count):
-            result[reg] = transformed_data.get(reg, 0)
-        return result
+        return {
+            reg: value
+            for reg, value in transformed_data.items()
+            if register <= reg < register + count
+        }
 
     mock_client.read = AsyncMock(side_effect=mock_read)
     mock_client.write = AsyncMock()


### PR DESCRIPTION
## Summary

Test fixtures store raw uint16 wire data (as exported by the diagnostics dump), but production stores the post-conversion view: signed-int temperatures and combined 32-bit values. The fixture loader was flattening fixtures into `coordinator.data` without running them through the same conversion as `KomfoventModbusClient.read()`, so negative temperatures and 32-bit register pairs looked wrong in tests but correct in production.

Discovered while planning #175 (water temperature sensor) — `REG_WATER_TEMP=905` reads as `+32768` in fixtures but `-32768` in production. The mismatch was self-cancelling for in-range temperatures and would have bitten the next test that relied on a real negative value (e.g. `tests/fixtures/C6M_registers_issue161.json:904 = 65517` → `+6551.7°C` in tests, `-1.9°C` in production).

## Changes

- Extract per-block conversion from `KomfoventModbusClient.read` into a module-level `convert_register_block` helper in `custom_components/komfovent/modbus.py`.
- Call the helper from `tests/conftest.py:load_register_fixture` and `mock_modbus_client` so test data matches production semantics.
- Filter unknown register addresses in the loader (scheduler 300-555, alarm history, mobile-app ranges) that the diagnostics dump captures but production never reads.

Diagnostics output stays raw on disk — that's the right format for debugging unknown device behavior, and fixture files are unchanged.

## Test plan

- [x] `uv run pytest` — 372 passed, 4 skipped (matches main baseline)
- [x] `uv run ruff format .` / `uv run ruff check . --fix` — clean
- [x] `uv run ty check` — no new warnings (4 pre-existing on main)
- [x] Diff coverage vs main: 100% (21/21 lines)
- [x] Spot check: `load_register_fixture("C6M_registers_issue161.json")[904] == -19` (-1.9°C outdoor, was +65517 raw); `[905] == -32768` (sentinel, was +32768 raw); register 14 absent from dict (consumed by 13's 32-bit combine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)