### PR TITLE
Add daily and monthly energy consumption sensors

### DIFF
--- a/custom_components/komfovent/sensor.py
+++ b/custom_components/komfovent/sensor.py
@@ -455,6 +455,32 @@ async def create_sensors(coordinator: KomfoventCoordinator) -> list[KomfoventSen
                 ),
                 FloatX1000Sensor(
                     coordinator=coordinator,
+                    register_id=registers.REG_AHU_DAY,
+                    entity_description=SensorEntityDescription(
+                        key="daily_ahu_energy",
+                        name="Daily AHU Energy",
+                        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+                        device_class=SensorDeviceClass.ENERGY,
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                        suggested_display_precision=3,
+                        entity_registry_enabled_default=False,
+                    ),
+                ),
+                FloatX1000Sensor(
+                    coordinator=coordinator,
+                    register_id=registers.REG_AHU_MONTH,
+                    entity_description=SensorEntityDescription(
+                        key="monthly_ahu_energy",
+                        name="Monthly AHU Energy",
+                        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+                        device_class=SensorDeviceClass.ENERGY,
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                        suggested_display_precision=3,
+                        entity_registry_enabled_default=False,
+                    ),
+                ),
+                FloatX1000Sensor(
+                    coordinator=coordinator,
                     register_id=registers.REG_AHU_TOTAL,
                     entity_description=SensorEntityDescription(
                         key="total_ahu_energy",
@@ -467,6 +493,32 @@ async def create_sensors(coordinator: KomfoventCoordinator) -> list[KomfoventSen
                 ),
                 FloatX1000Sensor(
                     coordinator=coordinator,
+                    register_id=registers.REG_HEATER_DAY,
+                    entity_description=SensorEntityDescription(
+                        key="daily_heater_energy",
+                        name="Daily Heater Energy",
+                        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+                        device_class=SensorDeviceClass.ENERGY,
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                        suggested_display_precision=3,
+                        entity_registry_enabled_default=False,
+                    ),
+                ),
+                FloatX1000Sensor(
+                    coordinator=coordinator,
+                    register_id=registers.REG_HEATER_MONTH,
+                    entity_description=SensorEntityDescription(
+                        key="monthly_heater_energy",
+                        name="Monthly Heater Energy",
+                        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+                        device_class=SensorDeviceClass.ENERGY,
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                        suggested_display_precision=3,
+                        entity_registry_enabled_default=False,
+                    ),
+                ),
+                FloatX1000Sensor(
+                    coordinator=coordinator,
                     register_id=registers.REG_HEATER_TOTAL,
                     entity_description=SensorEntityDescription(
                         key="total_heater_energy",
@@ -475,6 +527,32 @@ async def create_sensors(coordinator: KomfoventCoordinator) -> list[KomfoventSen
                         device_class=SensorDeviceClass.ENERGY,
                         state_class=SensorStateClass.TOTAL_INCREASING,
                         suggested_display_precision=3,
+                    ),
+                ),
+                FloatX1000Sensor(
+                    coordinator=coordinator,
+                    register_id=registers.REG_RECOVERY_DAY,
+                    entity_description=SensorEntityDescription(
+                        key="daily_recovered_energy",
+                        name="Daily Recovered Energy",
+                        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+                        device_class=SensorDeviceClass.ENERGY,
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                        suggested_display_precision=3,
+                        entity_registry_enabled_default=False,
+                    ),
+                ),
+                FloatX1000Sensor(
+                    coordinator=coordinator,
+                    register_id=registers.REG_RECOVERY_MONTH,
+                    entity_description=SensorEntityDescription(
+                        key="monthly_recovered_energy",
+                        name="Monthly Recovered Energy",
+                        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+                        device_class=SensorDeviceClass.ENERGY,
+                        state_class=SensorStateClass.TOTAL_INCREASING,
+                        suggested_display_precision=3,
+                        entity_registry_enabled_default=False,
                     ),
                 ),
                 FloatX1000Sensor(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -3,8 +3,12 @@
 from datetime import datetime
 
 import pytest
-from homeassistant.components.sensor import SensorEntityDescription
-from homeassistant.const import PERCENTAGE, UnitOfVolumeFlowRate
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import PERCENTAGE, UnitOfEnergy, UnitOfVolumeFlowRate
 
 from custom_components.komfovent import registers
 from custom_components.komfovent.const import (
@@ -355,11 +359,35 @@ def test_system_time_sensor(mock_coordinator, data, is_datetime):
 # ==================== Factory Functions ====================
 
 
+# All 9 energy counters are C6/C6M-only. Sorted by register address.
+# (key, register_id, entity_registry_enabled_default)
+ENERGY_ENTITIES = [
+    ("daily_ahu_energy", registers.REG_AHU_DAY, False),
+    ("monthly_ahu_energy", registers.REG_AHU_MONTH, False),
+    ("total_ahu_energy", registers.REG_AHU_TOTAL, True),
+    ("daily_heater_energy", registers.REG_HEATER_DAY, False),
+    ("monthly_heater_energy", registers.REG_HEATER_MONTH, False),
+    ("total_heater_energy", registers.REG_HEATER_TOTAL, True),
+    ("daily_recovered_energy", registers.REG_RECOVERY_DAY, False),
+    ("monthly_recovered_energy", registers.REG_RECOVERY_MONTH, False),
+    ("total_recovered_energy", registers.REG_RECOVERY_TOTAL, True),
+]
+ENERGY_KEYS = {entry[0] for entry in ENERGY_ENTITIES}
+
+
 @pytest.mark.parametrize(
     ("controller", "expected", "unexpected"),
     [
-        (Controller.C6, {"supply_temperature", "flow_unit"}, set()),
-        (Controller.C8, {"supply_temperature"}, {"flow_unit", "specific_power_input"}),
+        (
+            Controller.C6,
+            {"supply_temperature", "flow_unit"} | ENERGY_KEYS,
+            set(),
+        ),
+        (
+            Controller.C8,
+            {"supply_temperature"},
+            {"flow_unit", "specific_power_input"} | ENERGY_KEYS,
+        ),
     ],
 )
 async def test_create_sensors_controller(
@@ -371,6 +399,22 @@ async def test_create_sensors_controller(
     keys = {s.entity_description.key for s in sensors}
     assert expected <= keys
     assert not (unexpected & keys)
+
+
+@pytest.mark.parametrize(("key", "register_id", "enabled_default"), ENERGY_ENTITIES)
+async def test_energy_sensor_properties(
+    mock_coordinator, key, register_id, enabled_default
+):
+    """All C6 energy meters share the same HA shape: kWh, ENERGY, TOTAL_INCREASING."""
+    sensors = await create_sensors(mock_coordinator)
+    sensor = next(s for s in sensors if s.entity_description.key == key)
+    assert isinstance(sensor, FloatX1000Sensor)
+    assert sensor.register_id == register_id
+    desc = sensor.entity_description
+    assert desc.state_class == SensorStateClass.TOTAL_INCREASING
+    assert desc.device_class == SensorDeviceClass.ENERGY
+    assert desc.native_unit_of_measurement == UnitOfEnergy.KILO_WATT_HOUR
+    assert desc.entity_registry_enabled_default is enabled_default
 
 
 async def test_create_sensors_count(mock_coordinator):


### PR DESCRIPTION
## Summary

- Adds six new C6/C6M energy sensors mirroring the existing Total counters: daily/monthly AHU, heater, and recovered energy (`REG_AHU_DAY`/`MONTH`, `REG_HEATER_DAY`/`MONTH`, `REG_RECOVERY_DAY`/`MONTH`).
- All six are `entity_registry_enabled_default=False` so they don't show up in the HA Energy dashboard alongside the Totals (would double-count).
- All nine energy entities use `SensorStateClass.TOTAL_INCREASING` + `SensorDeviceClass.ENERGY` + kWh. Per HA developer docs, `TOTAL_INCREASING` is defined for "a monotonically increasing total that periodically restarts counting from 0" — daily gas/water are the canonical examples — and the recorder auto-detects at-midnight rollovers via the decreasing-value heuristic. `last_reset` is only needed for `SensorStateClass.TOTAL`.
- C8 has no equivalent registers, so the new entities sit inside the existing `Controller.C6/C6M` gate.

Discussion: #173

## Test plan

- [x] `uv run pytest` — 381 passed, 4 skipped (was 372 + 9 new property tests + parametrize spread)
- [x] `uv run ruff format .` — no changes
- [x] `uv run ruff check .` — clean
- [x] `uv run ty check` — same 4 pre-existing warnings on main, none in modified code
- [x] New parametrized `test_energy_sensor_properties` covers all 9 entities (3 Total + 6 Day/Month), asserting `state_class`, `device_class`, unit, `register_id`, and `entity_registry_enabled_default`
- [x] `test_create_sensors_controller` extended so all 9 energy keys are asserted as C6-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)