### PR TITLE
Remove PROBLEM device class from status_flow_down

### DIFF
--- a/custom_components/komfovent/binary_sensor.py
+++ b/custom_components/komfovent/binary_sensor.py
@@ -134,7 +134,6 @@ async def create_binary_sensors(
             entity_description=BinarySensorEntityDescription(
                 key="status_flow_down",
                 name="Status Flow Down",
-                device_class=BinarySensorDeviceClass.PROBLEM,
             ),
         ),
         KomfoventStatusBinarySensor(


### PR DESCRIPTION
## Summary
- Drop `device_class=BinarySensorDeviceClass.PROBLEM` from `status_flow_down`
- Flow Down is informational (a result of ECO mode reducing airflow), not a fault — consistent with `status_heating_denied` / `status_cooling_denied`, which are already unclassified
- Users who want it surfaced as a problem can set the device class per-entity in the HA UI; the reverse (clearing an integration-provided device class) is not possible from the UI, so defaulting to no class gives users the choice

Fixes #181

## Test plan
- [x] `uv run pytest` — 389 passed
- [x] `uv run ruff format .` / `uv run ruff check . --fix` / `uv run ty check` — all clean
- [x] `uv run diff-cover` — no new lines, nothing to cover
- [ ] Verify in HA UI that `binary_sensor.status_flow_down` now has no device class by default and can be set to `problem` via entity settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)