### PR TITLE
Migrate to typed ConfigEntry.runtime_data

### DIFF
--- a/custom_components/komfovent/__init__.py
+++ b/custom_components/komfovent/__init__.py
@@ -11,16 +11,16 @@ from homeassistant.const import Platform
 from .const import (
     DEFAULT_EMA_TIME_CONSTANT,
     DEFAULT_UPDATE_INTERVAL,
-    DOMAIN,
     OPT_EMA_TIME_CONSTANT,
     OPT_UPDATE_INTERVAL,
 )
-from .coordinator import KomfoventCoordinator
+from .coordinator import KomfoventCoordinator, KomfoventRuntimeData
 from .services import async_register_services
 
 if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
+
+    from .coordinator import KomfoventConfigEntry
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -37,7 +37,7 @@ PLATFORMS = [
 ]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: KomfoventConfigEntry) -> bool:
     """Set up Komfovent from a config entry."""
     update_interval = entry.options.get(OPT_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
     ema_time_constant = entry.options.get(
@@ -54,7 +54,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    entry.runtime_data = KomfoventRuntimeData(coordinator=coordinator)
 
     await async_register_services(hass)
 
@@ -65,9 +65,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def _async_update_listener(
+    hass: HomeAssistant,  # noqa: ARG001
+    entry: KomfoventConfigEntry,
+) -> None:
     """Handle options update."""
-    coordinator: KomfoventCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data.coordinator
     update_interval = entry.options.get(OPT_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
     coordinator.update_interval = timedelta(seconds=update_interval)
     coordinator.ema_time_constant = entry.options.get(
@@ -76,9 +79,6 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
     _LOGGER.debug("Update interval changed to %s seconds", update_interval)
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: KomfoventConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/custom_components/komfovent/binary_sensor.py
+++ b/custom_components/komfovent/binary_sensor.py
@@ -12,14 +12,12 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-    from .coordinator import KomfoventCoordinator
+    from .coordinator import KomfoventConfigEntry, KomfoventCoordinator
 
 from . import registers
-from .const import DOMAIN
 from .helpers import build_device_info
 
 # Status bitmask values
@@ -182,12 +180,12 @@ async def create_binary_sensors(
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,
-    entry: ConfigEntry,
+    hass: HomeAssistant,  # noqa: ARG001
+    entry: KomfoventConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Komfovent binary sensor based on a config entry."""
-    coordinator: KomfoventCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data.coordinator
     async_add_entities(await create_binary_sensors(coordinator))
 
 

--- a/custom_components/komfovent/button.py
+++ b/custom_components/komfovent/button.py
@@ -9,24 +9,22 @@ from homeassistant.const import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-    from .coordinator import KomfoventCoordinator
+    from .coordinator import KomfoventConfigEntry, KomfoventCoordinator
 
 from . import services
-from .const import DOMAIN
 from .helpers import build_device_info
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    hass: HomeAssistant,  # noqa: ARG001
+    config_entry: KomfoventConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Komfovent button from config entry."""
-    coordinator: KomfoventCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config_entry.runtime_data.coordinator
 
     async_add_entities(
         [

--- a/custom_components/komfovent/climate.py
+++ b/custom_components/komfovent/climate.py
@@ -21,18 +21,16 @@ from .binary_sensor import (
     BITMASK_HEATING,
 )
 from .const import (
-    DOMAIN,
     OperationMode,
     TemperatureControl,
 )
 from .helpers import build_device_info
 
 if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-    from .coordinator import KomfoventCoordinator
+    from .coordinator import KomfoventConfigEntry, KomfoventCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,12 +39,12 @@ SETPOINT_MAX_TEMP: Final = 40  # Maximum temperature supported by device (raw va
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,
-    entry: ConfigEntry,
+    hass: HomeAssistant,  # noqa: ARG001
+    entry: KomfoventConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Komfovent climate device."""
-    coordinator: KomfoventCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data.coordinator
     async_add_entities([KomfoventClimate(coordinator)])
 
 

--- a/custom_components/komfovent/coordinator.py
+++ b/custom_components/komfovent/coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -215,3 +216,18 @@ class KomfoventCoordinator(TimestampDataUpdateCoordinator[dict[int, Any]]):
                     tau=self.ema_time_constant,
                     dt=dt,
                 )
+
+
+@dataclass
+class KomfoventRuntimeData:
+    """
+    Runtime data stored on a Komfovent config entry.
+
+    Wraps the coordinator in a dataclass so additional per-entry runtime
+    objects can be added as fields without touching every platform.
+    """
+
+    coordinator: KomfoventCoordinator
+
+
+type KomfoventConfigEntry = ConfigEntry[KomfoventRuntimeData]

--- a/custom_components/komfovent/datetime.py
+++ b/custom_components/komfovent/datetime.py
@@ -11,24 +11,22 @@ from homeassistant.const import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-    from .coordinator import KomfoventCoordinator
+    from .coordinator import KomfoventConfigEntry, KomfoventCoordinator
 
 from . import registers
-from .const import DOMAIN
 from .helpers import build_device_info
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,
-    entry: ConfigEntry,
+    hass: HomeAssistant,  # noqa: ARG001
+    entry: KomfoventConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Komfovent datetime entities."""
-    coordinator: KomfoventCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data.coordinator
 
     async_add_entities(
         [

--- a/custom_components/komfovent/diagnostics.py
+++ b/custom_components/komfovent/diagnostics.py
@@ -9,15 +9,13 @@ from homeassistant.const import CONF_HOST, CONF_PORT
 from pymodbus import ModbusException
 from pymodbus.client import AsyncModbusTcpClient
 
-from .const import DOMAIN
 from .registers import REGISTERS_32BIT_UNSIGNED
 
 if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from pymodbus.pdu import ModbusPDU
 
-    from .coordinator import KomfoventCoordinator
+    from .coordinator import KomfoventConfigEntry
 
 logger = logging.getLogger(__name__)
 
@@ -147,10 +145,11 @@ async def dump_registers(host: str, port: int) -> dict[int, list[int]]:
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HomeAssistant,  # noqa: ARG001
+    entry: KomfoventConfigEntry,
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: KomfoventCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data.coordinator
 
     host = entry.data[CONF_HOST]
     port = entry.data[CONF_PORT]

--- a/custom_components/komfovent/number.py
+++ b/custom_components/komfovent/number.py
@@ -20,11 +20,10 @@ from homeassistant.const import (
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-    from .coordinator import KomfoventCoordinator
+    from .coordinator import KomfoventConfigEntry, KomfoventCoordinator
 
 from . import registers
 from .const import (
@@ -34,7 +33,6 @@ from .const import (
     DEFAULT_STEP_TEMPERATURE,
     DEFAULT_STEP_TIMER,
     DEFAULT_STEP_VOC,
-    DOMAIN,
     OPT_STEP_CO2,
     OPT_STEP_FLOW,
     OPT_STEP_HUMIDITY,
@@ -61,12 +59,12 @@ VOC_MAX = 100
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,
-    entry: ConfigEntry,
+    hass: HomeAssistant,  # noqa: ARG001
+    entry: KomfoventConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Komfovent number entities."""
-    coordinator: KomfoventCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data.coordinator
 
     step_temperature = entry.options.get(OPT_STEP_TEMPERATURE, DEFAULT_STEP_TEMPERATURE)
     step_flow = entry.options.get(OPT_STEP_FLOW, DEFAULT_STEP_FLOW)

--- a/custom_components/komfovent/select.py
+++ b/custom_components/komfovent/select.py
@@ -14,7 +14,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import registers, services
 from .const import (
-    DOMAIN,
     AirQualitySensorType,
     CoilType,
     Controller,
@@ -31,22 +30,21 @@ from .const import (
 from .helpers import build_device_info
 
 if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-    from .coordinator import KomfoventCoordinator
+    from .coordinator import KomfoventConfigEntry, KomfoventCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,
-    entry: ConfigEntry,
+    hass: HomeAssistant,  # noqa: ARG001
+    entry: KomfoventConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Komfovent select entities."""
-    coordinator: KomfoventCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data.coordinator
     entities = [
         KomfoventOperationModeSelect(
             coordinator=coordinator,

--- a/custom_components/komfovent/sensor.py
+++ b/custom_components/komfovent/sensor.py
@@ -30,17 +30,15 @@ from .helpers import build_device_info, get_version_from_int
 if TYPE_CHECKING:
     from decimal import Decimal
 
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
     from homeassistant.helpers.typing import StateType
 
-    from .coordinator import KomfoventCoordinator
+    from .coordinator import KomfoventConfigEntry, KomfoventCoordinator
 
 from . import registers
 from .const import (
     ALARM_CODE_MESSAGES,
-    DOMAIN,
     AirQualitySensorType,
     ConnectedPanels,
     Controller,
@@ -822,12 +820,12 @@ async def create_sensors(coordinator: KomfoventCoordinator) -> list[KomfoventSen
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,
-    entry: ConfigEntry,
+    hass: HomeAssistant,  # noqa: ARG001
+    entry: KomfoventConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Komfovent sensors."""
-    coordinator: KomfoventCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data.coordinator
 
     async_add_entities(await create_sensors(coordinator))
 

--- a/custom_components/komfovent/services.py
+++ b/custom_components/komfovent/services.py
@@ -4,6 +4,7 @@ import logging
 import zoneinfo
 from datetime import datetime
 
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr
 
@@ -25,8 +26,13 @@ def get_coordinator_for_device(
         return None
 
     for entry_id in device_entry.config_entries:
-        if coordinator := hass.data[DOMAIN].get(entry_id):
-            return coordinator
+        entry = hass.config_entries.async_get_entry(entry_id)
+        if (
+            entry is not None
+            and entry.domain == DOMAIN
+            and entry.state is ConfigEntryState.LOADED
+        ):
+            return entry.runtime_data.coordinator
     return None
 
 

--- a/custom_components/komfovent/switch.py
+++ b/custom_components/komfovent/switch.py
@@ -9,14 +9,12 @@ from homeassistant.const import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 if TYPE_CHECKING:
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-    from .coordinator import KomfoventCoordinator
+    from .coordinator import KomfoventConfigEntry, KomfoventCoordinator
 
 from . import registers
-from .const import DOMAIN
 from .helpers import build_device_info
 
 
@@ -204,12 +202,12 @@ async def create_switches(coordinator: KomfoventCoordinator) -> list[KomfoventSw
 
 
 async def async_setup_entry(
-    hass: HomeAssistant,
-    entry: ConfigEntry,
+    hass: HomeAssistant,  # noqa: ARG001
+    entry: KomfoventConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Komfovent switches."""
-    coordinator: KomfoventCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data.coordinator
 
     async_add_entities(await create_switches(coordinator))
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -8,6 +8,7 @@ from pymodbus import ModbusException
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.komfovent.const import DOMAIN
+from custom_components.komfovent.coordinator import KomfoventRuntimeData
 from custom_components.komfovent.diagnostics import (
     ERR_READ_FAILED,
     RANGES,
@@ -29,7 +30,7 @@ def mock_entry(hass):
     )
     mock_coordinator = MagicMock()
     mock_coordinator.data = {"test": "data"}
-    hass.data[DOMAIN] = {entry.entry_id: mock_coordinator}
+    entry.runtime_data = KomfoventRuntimeData(coordinator=mock_coordinator)
     return entry
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -18,6 +18,7 @@ from custom_components.komfovent.const import (
     DOMAIN,
     OPT_UPDATE_INTERVAL,
 )
+from custom_components.komfovent.coordinator import KomfoventRuntimeData
 
 
 @pytest.fixture
@@ -44,7 +45,6 @@ def mock_config_entry_with_options():
 async def test_setup_entry(hass: HomeAssistant, mock_config_entry, mock_modbus_client):
     """Test the integration sets up successfully."""
     # Initialize HomeAssistant mocks
-    hass.data.setdefault(DOMAIN, {})
     hass.services = AsyncMock()
     hass.services.async_register = MagicMock()  # Use sync mock for register
     hass.config = MagicMock()  # Use sync mock for config
@@ -77,13 +77,12 @@ async def test_setup_entry(hass: HomeAssistant, mock_config_entry, mock_modbus_c
         await coordinator.async_refresh()
 
         # Simulate what async_setup_entry does
-        hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = coordinator
+        mock_config_entry.runtime_data = KomfoventRuntimeData(coordinator=coordinator)
         await mock_register_services(hass)
         await hass.config_entries.async_forward_entry_setups(mock_config_entry, [])
 
-        # Verify data structures were created
-        assert mock_config_entry.entry_id in hass.data[DOMAIN]
-        coordinator = hass.data[DOMAIN][mock_config_entry.entry_id]
+        # Verify runtime data was stored on the entry
+        assert mock_config_entry.runtime_data.coordinator is coordinator
 
         # Verify coordinator has data
         assert coordinator.data is not None
@@ -184,10 +183,10 @@ class TestAsyncUpdateListener:
         mock_config_entry_with_updated_options,
     ):
         """Test update listener changes coordinator update_interval."""
-        # Set up hass.data with the coordinator
-        hass.data[DOMAIN] = {
-            mock_config_entry_with_updated_options.entry_id: mock_coordinator
-        }
+        # Attach runtime data with the coordinator to the entry
+        mock_config_entry_with_updated_options.runtime_data = KomfoventRuntimeData(
+            coordinator=mock_coordinator
+        )
 
         # Call the update listener
         await _async_update_listener(hass, mock_config_entry_with_updated_options)
@@ -199,8 +198,10 @@ class TestAsyncUpdateListener:
         self, hass: HomeAssistant, mock_coordinator, mock_config_entry
     ):
         """Test update listener uses default when option is missing."""
-        # Set up hass.data with the coordinator
-        hass.data[DOMAIN] = {mock_config_entry.entry_id: mock_coordinator}
+        # Attach runtime data with the coordinator to the entry
+        mock_config_entry.runtime_data = KomfoventRuntimeData(
+            coordinator=mock_coordinator
+        )
 
         # Call the update listener (options is empty by default in mock_config_entry)
         await _async_update_listener(hass, mock_config_entry)
@@ -217,27 +218,29 @@ class TestAsyncUnloadEntry:
     async def test_unload_entry_success(
         self, hass: HomeAssistant, mock_coordinator, mock_config_entry
     ):
-        """Test successful unload removes coordinator from hass.data."""
-        # Set up hass.data with the coordinator
-        hass.data[DOMAIN] = {mock_config_entry.entry_id: mock_coordinator}
+        """Test successful platform unload returns True."""
+        mock_config_entry.runtime_data = KomfoventRuntimeData(
+            coordinator=mock_coordinator
+        )
 
         with patch.object(
             hass.config_entries,
             "async_unload_platforms",
             new_callable=AsyncMock,
             return_value=True,
-        ):
+        ) as mock_unload:
             result = await async_unload_entry(hass, mock_config_entry)
 
         assert result is True
-        assert mock_config_entry.entry_id not in hass.data[DOMAIN]
+        mock_unload.assert_awaited_once()
 
-    async def test_unload_entry_failure_keeps_coordinator(
+    async def test_unload_entry_failure(
         self, hass: HomeAssistant, mock_coordinator, mock_config_entry
     ):
-        """Test failed unload keeps coordinator in hass.data."""
-        # Set up hass.data with the coordinator
-        hass.data[DOMAIN] = {mock_config_entry.entry_id: mock_coordinator}
+        """Test failed platform unload returns False."""
+        mock_config_entry.runtime_data = KomfoventRuntimeData(
+            coordinator=mock_coordinator
+        )
 
         with patch.object(
             hass.config_entries,
@@ -248,4 +251,3 @@ class TestAsyncUnloadEntry:
             result = await async_unload_entry(hass, mock_config_entry)
 
         assert result is False
-        assert mock_config_entry.entry_id in hass.data[DOMAIN]

--- a/tests/test_platform_setup.py
+++ b/tests/test_platform_setup.py
@@ -1,0 +1,47 @@
+"""Tests for the per-platform async_setup_entry functions."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.komfovent import (
+    binary_sensor,
+    button,
+    climate,
+    number,
+    select,
+    sensor,
+    switch,
+)
+from custom_components.komfovent import (
+    datetime as komfovent_datetime,
+)
+from custom_components.komfovent.coordinator import KomfoventRuntimeData
+
+PLATFORM_MODULES = [
+    binary_sensor,
+    button,
+    climate,
+    komfovent_datetime,
+    number,
+    select,
+    sensor,
+    switch,
+]
+
+
+@pytest.mark.parametrize(
+    "platform",
+    PLATFORM_MODULES,
+    ids=[module.__name__.rsplit(".", 1)[-1] for module in PLATFORM_MODULES],
+)
+async def test_platform_setup_reads_runtime_data(
+    hass, mock_config_entry, mock_coordinator, platform
+):
+    """Each platform reads the coordinator from entry.runtime_data and adds entities."""
+    mock_config_entry.runtime_data = KomfoventRuntimeData(coordinator=mock_coordinator)
+    async_add_entities = MagicMock()
+
+    await platform.async_setup_entry(hass, mock_config_entry, async_add_entities)
+
+    async_add_entities.assert_called_once()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 from unittest.mock import MagicMock, call, patch
 
 import pytest
+from homeassistant.config_entries import ConfigEntryState
 
 from custom_components.komfovent import registers
 from custom_components.komfovent.const import (
@@ -12,6 +13,7 @@ from custom_components.komfovent.const import (
     Controller,
     OperationMode,
 )
+from custom_components.komfovent.coordinator import KomfoventRuntimeData
 from custom_components.komfovent.services import (
     DEFAULT_MODE_TIMER,
     async_register_services,
@@ -162,11 +164,22 @@ async def test_set_system_time_writes_epoch(mock_coordinator, controller, func_v
     assert value > 0
 
 
+def _mock_loaded_entry(coordinator):
+    """Build a mock LOADED komfovent config entry exposing the coordinator."""
+    entry = MagicMock()
+    entry.domain = DOMAIN
+    entry.state = ConfigEntryState.LOADED
+    entry.runtime_data = KomfoventRuntimeData(coordinator=coordinator)
+    return entry
+
+
 @pytest.mark.parametrize(("setup", "expected"), [(True, True), (False, False)])
 def test_get_coordinator_for_device(hass, setup, expected):
     """Test get_coordinator_for_device returns correct result."""
     mock_coordinator = MagicMock()
-    hass.data[DOMAIN] = {"test_entry_id": mock_coordinator} if setup else {}
+    hass.config_entries.async_get_entry.return_value = (
+        _mock_loaded_entry(mock_coordinator) if setup else None
+    )
     mock_device = MagicMock() if setup else None
     if mock_device:
         mock_device.config_entries = ["test_entry_id"]
@@ -180,7 +193,7 @@ def test_get_coordinator_for_device(hass, setup, expected):
 
 def test_device_without_coordinator(hass):
     """Test returns None when device has no matching coordinator."""
-    hass.data[DOMAIN] = {}
+    hass.config_entries.async_get_entry.return_value = None
     mock_device = MagicMock()
     mock_device.config_entries = ["nonexistent_entry"]
     with patch("custom_components.komfovent.services.dr.async_get") as mock_get:
@@ -192,7 +205,9 @@ def test_device_without_coordinator(hass):
 
 async def test_handle_clear_active_alarms(hass, mock_coordinator):
     """Test handle_clear_active_alarms service handler."""
-    hass.data[DOMAIN] = {"test_entry_id": mock_coordinator}
+    hass.config_entries.async_get_entry.return_value = _mock_loaded_entry(
+        mock_coordinator
+    )
     await async_register_services(hass)
 
     # Get the handler that was registered for clear_active_alarms
@@ -217,7 +232,6 @@ async def test_handle_clear_active_alarms(hass, mock_coordinator):
 
 async def test_handle_clear_active_alarms_device_not_found(hass):
     """Test handle_clear_active_alarms when device not found."""
-    hass.data[DOMAIN] = {}
     await async_register_services(hass)
 
     calls = hass.services.async_register.call_args_list
@@ -234,7 +248,6 @@ async def test_handle_clear_active_alarms_device_not_found(hass):
 
 async def test_registers_all_services(hass):
     """Test that all services are registered."""
-    hass.data[DOMAIN] = {}
     await async_register_services(hass)
     assert hass.services.async_register.call_count == 4
     services = [call[0][1] for call in hass.services.async_register.call_args_list]


### PR DESCRIPTION
## Summary

Replaces the hand-rolled `hass.data[DOMAIN][entry_id]` storage with Home Assistant's typed `ConfigEntry.runtime_data` slot — the officially supported, statically-typed, lifecycle-managed place for per-entry runtime data.

This is a **behavior-preserving refactor**. It's split out as its own PR ahead of the firmware-update feature, which needs to carry a second per-entry object (a firmware store) alongside the coordinator. Landing the `runtime_data` shape here keeps that feature PR purely additive.

## What changed

- **New types** (`coordinator.py`): a single-field `KomfoventRuntimeData` dataclass wrapping the coordinator, plus `type KomfoventConfigEntry = ConfigEntry[KomfoventRuntimeData]`. The wrapper is intentional headroom so future per-entry objects can be added as fields without touching every platform again.
- **`__init__.py`**: store the coordinator via `entry.runtime_data`; drop the manual `hass.data` pop in `async_unload_entry` (HA clears `runtime_data` automatically on unload).
- **All 8 platforms + diagnostics**: read `entry.runtime_data.coordinator`; drop now-unused `DOMAIN` imports. `hass` is unused in the framework-mandated setup signatures, marked with a scoped `# noqa: ARG001`.
- **`services.py`**: `get_coordinator_for_device` resolves the entry via `hass.config_entries.async_get_entry`, guarding on `domain` and `ConfigEntryState.LOADED` before reading `runtime_data`.
- **Tests**: updated to set `entry.runtime_data` instead of `hass.data`; added `tests/test_platform_setup.py` covering each platform's `async_setup_entry`.

## Verification

- `ruff format` / `ruff check` — clean
- `ty check` — passes
- `pytest` — 402 passed, 4 skipped
- diff coverage vs main — 100%

## Note for reviewers

Unused `hass` params use `# noqa: ARG001` (framework-mandated signatures). HA core sidesteps this by not enabling `ARG001`; a `per-file-ignores` entry is an alternative if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)