### PR TITLE
Add separate panel firmware version parsing

### DIFF
--- a/custom_components/komfovent/const.py
+++ b/custom_components/komfovent/const.py
@@ -43,6 +43,13 @@ class Controller(IntEnum):
     NA = 15
 
 
+class Panel(IntEnum):
+    """Control panel types for firmware versioning."""
+
+    P1 = 0
+    NA = 15
+
+
 class OperationMode(IntEnum):
     """Operation modes."""
 

--- a/custom_components/komfovent/coordinator.py
+++ b/custom_components/komfovent/coordinator.py
@@ -26,7 +26,7 @@ from .const import (
     Controller,
 )
 from .core.ema import apply_ema
-from .helpers import get_version_from_int
+from .helpers import get_controller_version
 from .modbus import KomfoventModbusClient
 
 if TYPE_CHECKING:
@@ -94,7 +94,7 @@ class KomfoventCoordinator(TimestampDataUpdateCoordinator[dict[int, Any]]):
         try:
             # Get firmware version and extract functional version from it
             fw_data = await self.client.read(registers.REG_FIRMWARE, 2)
-            fw_version = get_version_from_int(fw_data.get(registers.REG_FIRMWARE, 0))
+            fw_version = get_controller_version(fw_data.get(registers.REG_FIRMWARE, 0))
             self.controller = fw_version[0]
             self.func_version = fw_version[4]
         except (ConnectionError, ModbusException) as error:

--- a/custom_components/komfovent/helpers.py
+++ b/custom_components/komfovent/helpers.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from homeassistant.const import CONF_HOST
 from homeassistant.helpers.device_registry import DeviceInfo
 
-from .const import DOMAIN, Controller
+from .const import DOMAIN, Controller, Panel
 
 if TYPE_CHECKING:
     from .coordinator import KomfoventCoordinator
@@ -43,9 +43,37 @@ def build_device_info(coordinator: KomfoventCoordinator) -> DeviceInfo:
     )
 
 
-def get_version_from_int(value: int) -> tuple[Controller, int, int, int, int]:
+def _unpack_version(value: int) -> tuple[int, int, int, int, int]:
     """
-    Convert integer version to component numbers.
+    Unpack a packed firmware version integer into its bitfields.
+
+    The most significant nibble encodes the device type (controller or
+    panel); the remaining fields are the four version numbers.
+
+    Args:
+        value: Integer containing version information packed as bitfields
+
+    Returns:
+        Tuple of (type, v1, v2, v3, v4) raw numbers
+
+    """
+    # device type 4bit <<28
+    # 1st number 4bit <<24
+    # 2nd number 4bit <<20
+    # 3rd number 8bit <<12
+    # 4th number 12bit <<0
+    # Example: 18886660 => 1.2.3.4
+    device_type = (value >> 28) & 0xF
+    v1 = (value >> 24) & 0xF
+    v2 = (value >> 20) & 0xF
+    v3 = (value >> 12) & 0xFF
+    v4 = value & 0xFFF
+    return device_type, v1, v2, v3, v4
+
+
+def get_controller_version(value: int) -> tuple[Controller, int, int, int, int]:
+    """
+    Convert integer version to a controller version tuple.
 
     Args:
         value: Integer containing version information packed as bitfields
@@ -54,22 +82,35 @@ def get_version_from_int(value: int) -> tuple[Controller, int, int, int, int]:
         Tuple of (controller, v1, v2, v3, v4) version numbers
 
     """
-    # controller 4bit <<28
-    # 1st number 4bit <<24
-    # 2nd number 4bit <<20
-    # 3rd number 8bit <<12
-    # 4th number 12bit <<0
-    # Example: 18886660 => 1.2.3.4
-
-    ct = (value >> 28) & 0xF
-    v1 = (value >> 24) & 0xF
-    v2 = (value >> 20) & 0xF
-    v3 = (value >> 12) & 0xFF
-    v4 = value & 0xFFF
+    device_type, v1, v2, v3, v4 = _unpack_version(value)
 
     try:
-        controller = Controller(ct)
+        controller = Controller(device_type)
     except ValueError:
         controller = Controller.NA
 
     return controller, v1, v2, v3, v4
+
+
+def get_panel_version(value: int) -> tuple[Panel, int, int, int, int]:
+    """
+    Convert integer version to a control panel version tuple.
+
+    Uses the same bitfield layout as the controller version, but the
+    device-type nibble is interpreted as a panel type.
+
+    Args:
+        value: Integer containing version information packed as bitfields
+
+    Returns:
+        Tuple of (panel, v1, v2, v3, v4) version numbers
+
+    """
+    device_type, v1, v2, v3, v4 = _unpack_version(value)
+
+    try:
+        panel = Panel(device_type)
+    except ValueError:
+        panel = Panel.NA
+
+    return panel, v1, v2, v3, v4

--- a/custom_components/komfovent/sensor.py
+++ b/custom_components/komfovent/sensor.py
@@ -25,7 +25,7 @@ from homeassistant.const import (
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .helpers import build_device_info, get_version_from_int
+from .helpers import build_device_info, get_controller_version, get_panel_version
 
 if TYPE_CHECKING:
     from decimal import Decimal
@@ -410,7 +410,7 @@ async def create_sensors(coordinator: KomfoventCoordinator) -> list[KomfoventSen
                     suggested_display_precision=0,
                 ),
             ),
-            FirmwareVersionSensor(
+            ControllerFirmwareVersionSensor(
                 coordinator=coordinator,
                 register_id=registers.REG_FIRMWARE,
                 entity_description=SensorEntityDescription(
@@ -742,7 +742,7 @@ async def create_sensors(coordinator: KomfoventCoordinator) -> list[KomfoventSen
                         suggested_display_precision=0,
                     ),
                 ),
-                FirmwareVersionSensor(
+                PanelFirmwareVersionSensor(
                     coordinator=coordinator,
                     register_id=registers.REG_PANEL1_FW,
                     entity_description=SensorEntityDescription(
@@ -785,7 +785,7 @@ async def create_sensors(coordinator: KomfoventCoordinator) -> list[KomfoventSen
                         suggested_display_precision=0,
                     ),
                 ),
-                FirmwareVersionSensor(
+                PanelFirmwareVersionSensor(
                     coordinator=coordinator,
                     register_id=registers.REG_PANEL2_FW,
                     entity_description=SensorEntityDescription(
@@ -920,7 +920,11 @@ class FloatX1000Sensor(KomfoventSensor):
 
 
 class FirmwareVersionSensor(KomfoventSensor):
-    """Firmware version sensor."""
+    """Base firmware version sensor for a packed version register."""
+
+    def _format_version(self, value: int) -> str:
+        """Format a packed version integer into a display string."""
+        raise NotImplementedError
 
     @property
     def native_value(self) -> str | None:
@@ -937,8 +941,25 @@ class FirmwareVersionSensor(KomfoventSensor):
         except (ValueError, TypeError):
             return None
 
-        controller, v1, v2, v3, v4 = get_version_from_int(value)
+        return self._format_version(value)
+
+
+class ControllerFirmwareVersionSensor(FirmwareVersionSensor):
+    """Controller firmware version sensor."""
+
+    def _format_version(self, value: int) -> str:
+        """Format the controller firmware version."""
+        controller, v1, v2, v3, v4 = get_controller_version(value)
         return f"{controller.name} {v1}.{v2}.{v3}.{v4}"
+
+
+class PanelFirmwareVersionSensor(FirmwareVersionSensor):
+    """Control panel firmware version sensor."""
+
+    def _format_version(self, value: int) -> str:
+        """Format the panel firmware version."""
+        panel, v1, v2, v3, v4 = get_panel_version(value)
+        return f"{panel.name} {v1}.{v2}.{v3}.{v4}"
 
 
 class DutyCycleSensor(FloatX10Sensor):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,44 +1,63 @@
 """Test cases for Komfovent helper functions."""
 
-from custom_components.komfovent.const import DOMAIN, Controller
-from custom_components.komfovent.helpers import build_device_info, get_version_from_int
+from custom_components.komfovent.const import DOMAIN, Controller, Panel
+from custom_components.komfovent.helpers import (
+    build_device_info,
+    get_controller_version,
+    get_panel_version,
+)
 
 
 def uint32(high, low):
     return (high << 16) + low
 
 
-def test_get_version_from_int():
-    """Test version number extraction from packed integer."""
+def test_get_controller_version():
+    """Test controller version extraction from packed integer."""
     # Test the example case from the docstring
-    assert get_version_from_int(18886660) == (Controller.C6, 1, 2, 3, 4)
+    assert get_controller_version(18886660) == (Controller.C6, 1, 2, 3, 4)
 
     # Test C6 controller firmware version
-    assert get_version_from_int(uint32(305, 4116)) == (Controller.C6, 1, 3, 17, 20)
-    assert get_version_from_int(20037670) == (Controller.C6, 1, 3, 28, 38)
-    assert get_version_from_int(uint32(305, 49190)) == (Controller.C6, 1, 3, 28, 38)
-    assert get_version_from_int(20099140) == (Controller.C6, 1, 3, 43, 68)
-    assert get_version_from_int(20103237) == (Controller.C6, 1, 3, 44, 69)
+    assert get_controller_version(uint32(305, 4116)) == (Controller.C6, 1, 3, 17, 20)
+    assert get_controller_version(20037670) == (Controller.C6, 1, 3, 28, 38)
+    assert get_controller_version(uint32(305, 49190)) == (Controller.C6, 1, 3, 28, 38)
+    assert get_controller_version(20099140) == (Controller.C6, 1, 3, 43, 68)
+    assert get_controller_version(20103237) == (Controller.C6, 1, 3, 44, 69)
 
     # Test C6M controller firmware version
-    assert get_version_from_int(289542195) == (Controller.C6M, 1, 4, 33, 51)
-    assert get_version_from_int(289579075) == (Controller.C6M, 1, 4, 42, 67)
-    assert get_version_from_int(uint32(4418, 41027)) == (Controller.C6M, 1, 4, 42, 67)
-    assert get_version_from_int(uint32(4418, 49221)) == (Controller.C6M, 1, 4, 44, 69)
+    assert get_controller_version(289542195) == (Controller.C6M, 1, 4, 33, 51)
+    assert get_controller_version(289579075) == (Controller.C6M, 1, 4, 42, 67)
+    assert get_controller_version(uint32(4418, 41027)) == (Controller.C6M, 1, 4, 42, 67)
+    assert get_controller_version(uint32(4418, 49221)) == (Controller.C6M, 1, 4, 44, 69)
 
     # Test C8 controller firmware version
-    assert get_version_from_int(uint32(8464, 12301)) == (Controller.C8, 1, 1, 3, 13)
-
-    # Test additional cases for C6 panel firmware version
-    assert get_version_from_int(17838105) == (Controller.C6, 1, 1, 3, 25)
-    assert get_version_from_int(18886683) == (Controller.C6, 1, 2, 3, 27)
-    assert get_version_from_int(17838114) == (Controller.C6, 1, 1, 3, 34)
-    assert get_version_from_int(17846317) == (Controller.C6, 1, 1, 5, 45)
-    assert get_version_from_int(34607113) == (Controller.C6, 2, 1, 1, 9)
+    assert get_controller_version(uint32(8464, 12301)) == (Controller.C8, 1, 1, 3, 13)
 
     # Test boundary values
-    assert get_version_from_int(0) == (Controller.C6, 0, 0, 0, 0)
-    assert get_version_from_int(0xFFFFFFFF) == (Controller.NA, 15, 15, 255, 4095)
+    assert get_controller_version(0) == (Controller.C6, 0, 0, 0, 0)
+    assert get_controller_version(0xFFFFFFFF) == (Controller.NA, 15, 15, 255, 4095)
+
+
+def test_get_panel_version():
+    """
+    Test panel version extraction from packed integer.
+
+    Panel firmware registers use the same bitfield layout, but the
+    device-type nibble maps to a Panel rather than a Controller.
+    """
+    # Real P1 panel firmware register values (device-type nibble 0 => P1)
+    assert get_panel_version(17838105) == (Panel.P1, 1, 1, 3, 25)
+    assert get_panel_version(18886683) == (Panel.P1, 1, 2, 3, 27)
+    assert get_panel_version(17838114) == (Panel.P1, 1, 1, 3, 34)
+    assert get_panel_version(17846317) == (Panel.P1, 1, 1, 5, 45)
+    assert get_panel_version(34607113) == (Panel.P1, 2, 1, 1, 9)
+
+    # Test boundary values
+    assert get_panel_version(0) == (Panel.P1, 0, 0, 0, 0)
+    assert get_panel_version(0xFFFFFFFF) == (Panel.NA, 15, 15, 255, 4095)
+
+    # Unknown panel type nibble (not 0 or 15) falls back to NA
+    assert get_panel_version(0x20000000) == (Panel.NA, 0, 0, 0, 0)
 
 
 def test_build_device_info(mock_coordinator):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -28,8 +28,8 @@ from custom_components.komfovent.sensor import (
     ActiveAlarmsSensor,
     CO2Sensor,
     ConnectedPanelsSensor,
+    ControllerFirmwareVersionSensor,
     DutyCycleSensor,
-    FirmwareVersionSensor,
     FloatSensor,
     FloatX10Sensor,
     FloatX100Sensor,
@@ -38,6 +38,7 @@ from custom_components.komfovent.sensor import (
     FlowUnitSensor,
     HeatExchangerTypeSensor,
     KomfoventSensor,
+    PanelFirmwareVersionSensor,
     RelativeHumiditySensor,
     SPISensor,
     SystemTimeSensor,
@@ -300,17 +301,30 @@ def test_enum_sensors_invalid(mock_coordinator, sensor_class):
 
 
 class TestFirmwareVersionSensor:
-    """Tests for FirmwareVersionSensor."""
+    """Tests for the firmware version sensors."""
 
     @pytest.mark.parametrize(
         ("value", "expected"),
         [(18886660, "C6 1.2.3.4"), (0, None), ("invalid", None), (None, None)],
     )
-    def test_firmware_values(self, mock_coordinator, value, expected):
-        """Test firmware version parsing."""
+    def test_controller_firmware_values(self, mock_coordinator, value, expected):
+        """Test controller firmware version parsing."""
         mock_coordinator.data = None if value is None else {100: value}
         assert (
-            FirmwareVersionSensor(mock_coordinator, 100, DESC).native_value == expected
+            ControllerFirmwareVersionSensor(mock_coordinator, 100, DESC).native_value
+            == expected
+        )
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [(17838105, "P1 1.1.3.25"), (0, None), ("invalid", None), (None, None)],
+    )
+    def test_panel_firmware_values(self, mock_coordinator, value, expected):
+        """Test panel firmware version parsing uses the panel type prefix."""
+        mock_coordinator.data = None if value is None else {100: value}
+        assert (
+            PanelFirmwareVersionSensor(mock_coordinator, 100, DESC).native_value
+            == expected
         )
 
 


### PR DESCRIPTION
## Summary

Isolates a firmware-version parsing improvement out of the larger firmware-update PR (#136), and makes it *complete* by actually wiring the panel parser into the panel firmware sensors.

The panel firmware registers (`REG_PANEL1_FW` / `REG_PANEL2_FW`) encode a **panel** type in the most-significant nibble, not a controller type. On `main`, both the controller and panel firmware sensors share a single `Controller`-based parser, so a connected panel renders a **bogus controller prefix** — e.g. `C6 1.1.3.25` instead of `P1 1.1.3.25`.

## What changed

- **`helpers.py`**: rename `get_version_from_int` → `get_controller_version`, and factor the shared bitfield unpacking into a private `_unpack_version()` helper (no duplicated shifts).
- **`const.py`**: add a `Panel` enum (`P1`, `NA`) for panel firmware versioning.
- **`helpers.py`**: add `get_panel_version()`, which uses the same bitfield layout but interprets the type nibble as a panel type.
- **`sensor.py`**: split `FirmwareVersionSensor` into a small base class plus `ControllerFirmwareVersionSensor` / `PanelFirmwareVersionSensor`, and point the panel firmware sensors at the panel parser.
- **`coordinator.py`**: follow the rename.

## Behaviour

- Controller firmware sensor: **unchanged** (still `C6 1.2.3.4`, etc.).
- Panel 1/2 firmware sensors: now show the correct **panel** prefix (`P1 …`) instead of a controller prefix.

## Why isolated

Same rationale as the `ConfigEntry.runtime_data` migration (#186): this is a small, self-contained, fully-tested change that touches existing code. Landing it on `main` shrinks the firmware-update PR's diff and de-risks its review, and it fixes a real display bug on its own.

## Verification

- `ruff format` / `ruff check` — clean
- `ty check` — passes
- `pytest` — 407 passed, 4 skipped
- diff coverage vs main — **100%** (new `get_panel_version` and both sensor variants covered, including the unknown-panel-type fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)