### PR TITLE
Stop dependabot ratcheting runtime floors and unblock phcc updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,14 +20,16 @@ updates:
       home-assistant-test-stack:
         patterns:
           - "pytest-homeassistant-custom-component"
+          - "homeassistant"
+          - "pytest"
+          - "pytest-asyncio"
+          - "pytest-cov"
       dev-tooling:
         dependency-type: "development"
         exclude-patterns:
           - "pytest-homeassistant-custom-component"
+          - "pytest"
+          - "pytest-asyncio"
+          - "pytest-cov"
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "homeassistant"
-      - dependency-name: "pytest"
-      - dependency-name: "pytest-asyncio"
-      - dependency-name: "pytest-cov"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 dependencies = [
     "homeassistant>=2026.3.0",
-    "pymodbus>=3.10.0",
+    "pymodbus",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -1096,7 +1096,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.3.0" },
-    { name = "pymodbus", specifier = ">=3.10.0" },
+    { name = "pymodbus" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Follow-up to the previous dependabot change, correcting two things the first run exposed.

## 1. `versioning-strategy` is a no-op for uv

[hass-komfovent#205](https://github.com/lnagel/hass-komfovent/pull/205) bumped `pymodbus>=3.10.0` → `>=3.15.0` even though 3.15.0 already satisfied the floor — and it was generated *under* the new config, since merging `dependabot.yml` triggers the run. So `increase-if-necessary` is not honoured by dependabot's uv ecosystem; it appears to fall back to `increase`.

That means the previous PR worked for the dev tools **only because their specifiers were bared**, not because of the strategy key. Removing the floor is the fix that doesn't depend on dependabot honouring anything, so the same treatment now applies to the runtime dependencies:

```diff
 dependencies = [
     "homeassistant>=2026.3.0",
-    "pymodbus>=3.10.0",
+    "pymodbus",
 ]
```

The real constraint stays in `manifest.json` — the file Home Assistant actually reads and enforces at install time. `pyproject.toml` exists only to build the test venv, so a floor there duplicated the constraint somewhere nothing consumes it, while handing dependabot something to ratchet. One source of truth closes the pyproject/manifest drift permanently instead of relying on a config key that turns out to do nothing.

**Keeping these floors permissive matters.** HA core's built-in `modbus` integration pins `pymodbus==3.13.1`. A manifest floor of `>=3.10.0` coexists with that; ratcheting it would eventually break users running both integrations. The drift I originally called a bug was, in this direction, protecting you.

`homeassistant>=2026.3.0` is left alone — it's the declared baseline, and phcc's exact pin means dependabot can't move it independently.

## 2. The ignore list silently blocked phcc

phcc 0.13.356 was released 2026-08-15 and skipped by the 2026-08-16 run. Comparing the two releases, the only dependency it changes is its exact HA pin:

| | 0.13.355 | 0.13.356 |
|---|---|---|
| `pytest` | 9.0.3 | 9.0.3 |
| `pytest-asyncio` | 1.4.0 | 1.4.0 |
| `pytest-cov` | 7.1.0 | 7.1.0 |
| `homeassistant` | **2026.8.1** | **2026.8.2** |

`homeassistant` was in `ignore`, and dependabot won't produce an update that moves an ignored dependency — so the phcc bump had nowhere to resolve to and was dropped without a PR.

The same trap applied to `pytest`, `pytest-asyncio` and `pytest-cov`: phcc pins all three exactly, so any future phcc release moving one of them would have been dropped identically. Every ignore entry for a package phcc pins was a latent blocker on phcc itself.

Removing them is safe *precisely because* those pins are exact — dependabot has no freedom to propose a standalone update for any of them, so the list was never doing real work. They move into the existing `home-assistant-test-stack` group so phcc and its pinned peers arrive in one reviewable PR.

## Verification

`uv lock` changed **no package versions** — the only lockfile deltas are the dropped specifier strings. All four suites pass locally: komfovent 410, eaton 318, navirec 144, ufh-controller 773.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4J3dxHPjuNbfkqibVYunB
