### PR TITLE
Let phcc own the Home Assistant test stack

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,21 +15,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    versioning-strategy: increase-if-necessary
     groups:
       home-assistant-test-stack:
         patterns:
           - "pytest-homeassistant-custom-component"
-          - "homeassistant"
-          - "pytest"
-          - "pytest-asyncio"
-          - "pytest-cov"
       dev-tooling:
         dependency-type: "development"
         exclude-patterns:
           - "pytest-homeassistant-custom-component"
-          - "pytest"
-          - "pytest-asyncio"
-          - "pytest-cov"
         patterns:
           - "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,15 +8,11 @@ authors = [
     { name = "lnagel", email = "lnagel@users.noreply.github.com" }
 ]
 dependencies = [
-    "homeassistant>=2026.3.0",
     "pymodbus",
 ]
 
 [dependency-groups]
 dev = [
-    "pytest",
-    "pytest-asyncio",
-    "pytest-cov",
     "pytest-homeassistant-custom-component==0.13.355",
     "bump-my-version",
     "diff-cover",

--- a/uv.lock
+++ b/uv.lock
@@ -1077,7 +1077,6 @@ name = "hass-komfovent"
 version = "0.10.4"
 source = { virtual = "." }
 dependencies = [
-    { name = "homeassistant" },
     { name = "pymodbus" },
 ]
 
@@ -1085,27 +1084,18 @@ dependencies = [
 dev = [
     { name = "bump-my-version" },
     { name = "diff-cover" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
     { name = "pytest-homeassistant-custom-component" },
     { name = "ruff" },
     { name = "ty" },
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "homeassistant", specifier = ">=2026.3.0" },
-    { name = "pymodbus" },
-]
+requires-dist = [{ name = "pymodbus" }]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "bump-my-version" },
     { name = "diff-cover" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
     { name = "pytest-homeassistant-custom-component", specifier = "==0.13.355" },
     { name = "ruff" },
     { name = "ty" },


### PR DESCRIPTION
Trial fix on this repo only. If dependabot behaves as intended for one cycle, the same change goes to the other four.

## What broke

The last run errored with `No solution found`:

> Because `pytest-homeassistant-custom-component==0.13.355` depends on `pytest==9.0.3` and `hass-komfovent:dev` depends on `pytest==9.1.1`, we can conclude that [they] are incompatible.

Dependabot doesn't check feasibility first — it writes `pytest==9.1.1` into the manifest and asks uv to resolve. That fails, and the failure aborts the **entire ecosystem run**, so no PRs were produced at all.

Any directly-declared package that phcc pins exactly is an unsatisfiable update waiting to happen. Putting them in `ignore` stops the attempt, but also blocks phcc itself — a phcc bump has to move them. `ignore` can't express "don't attempt this, but do accept it when phcc moves it".

## Fix: stop declaring what phcc owns

`homeassistant`, `pytest`, `pytest-asyncio` and `pytest-cov` are phcc's to control, so they come out of `pyproject.toml` and arrive transitively at the versions phcc pins.

```diff
 dependencies = [
-    "homeassistant>=2026.3.0",
     "pymodbus",
 ]

 [dependency-groups]
 dev = [
-    "pytest",
-    "pytest-asyncio",
-    "pytest-cov",
     "pytest-homeassistant-custom-component==0.13.355",
     "bump-my-version",
     "diff-cover",
     "ruff",
     "ty",
 ]
```

All four remain in `uv.lock` at identical versions — `homeassistant 2026.8.1`, `pytest 9.0.3`, `pytest-asyncio 1.4.0`, `pytest-cov 7.1.0`.

phcc is now the only attemptable dependency in the test stack, and whatever it drags along is lockfile fallout inside its own PR. The `ignore` list is no longer needed and is removed. Dev tooling keeps its own group and its own PR.

The HA baseline is unaffected — `hacs.json` already declares `"homeassistant": "2026.3.0"`, which is what HACS enforces.

`versioning-strategy` is dropped too: #205 bumped `pymodbus>=3.10.0` → `>=3.15.0` under `increase-if-necessary` when 3.15.0 already satisfied the floor, so it isn't honoured by dependabot's uv ecosystem.

## Expected next run

One PR bumping phcc `0.13.355 → 0.13.356`, carrying `homeassistant 2026.8.1 → 2026.8.2` in the lockfile, plus a separate dev-tooling PR. Nothing else attemptable, so nothing to error on.

## Verification

No package versions changed in `uv.lock`. 410 passed / 4 skipped, `ruff check` and `ty check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4J3dxHPjuNbfkqibVYunB
