### PR TITLE
Split DX unit sensor into DX Heating and DX Cooling

### DIFF
--- a/custom_components/komfovent/sensor.py
+++ b/custom_components/komfovent/sensor.py
@@ -252,12 +252,24 @@ async def create_sensors(coordinator: KomfoventCoordinator) -> list[KomfoventSen
                     entity_registry_enabled_default=False,
                 ),
             ),
-            DutyCycleSensor(
+            DxHeatingSensor(
                 coordinator=coordinator,
                 register_id=registers.REG_DX_UNIT,
                 entity_description=SensorEntityDescription(
-                    key="dx_unit",
-                    name="DX Unit",
+                    key="dx_heating",
+                    name="DX Heating",
+                    native_unit_of_measurement=PERCENTAGE,
+                    state_class=SensorStateClass.MEASUREMENT,
+                    suggested_display_precision=0,
+                    entity_registry_enabled_default=False,
+                ),
+            ),
+            DxCoolingSensor(
+                coordinator=coordinator,
+                register_id=registers.REG_DX_UNIT,
+                entity_description=SensorEntityDescription(
+                    key="dx_cooling",
+                    name="DX Cooling",
                     native_unit_of_measurement=PERCENTAGE,
                     state_class=SensorStateClass.MEASUREMENT,
                     suggested_display_precision=0,
@@ -980,6 +992,47 @@ class DutyCycleSensor(FloatX10Sensor):
         if MIN_DUTY_CYCLE <= value <= MAX_DUTY_CYCLE:
             return value
         return None
+
+
+class DxUnitSensor(FloatX10Sensor):
+    """Signed DX unit signal: negative is cooling, positive is heating."""
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the signed DX level if within valid range."""
+        value = super().native_value
+        if value is None:
+            return None
+
+        if -MAX_DUTY_CYCLE <= value <= MAX_DUTY_CYCLE:
+            return value
+        return None
+
+
+class DxHeatingSensor(DxUnitSensor):
+    """Heating duty cycle of the DX unit."""
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the heating share of the signal, zero while cooling."""
+        value = super().native_value
+        if value is None:
+            return None
+
+        return max(value, 0.0)
+
+
+class DxCoolingSensor(DxUnitSensor):
+    """Cooling duty cycle of the DX unit."""
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the cooling share of the signal, zero while heating."""
+        value = super().native_value
+        if value is None:
+            return None
+
+        return max(0.0, -value)
 
 
 class TemperatureSensor(FloatX10Sensor):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,5 +1,6 @@
 """Tests for Komfovent sensor platform."""
 
+import math
 from datetime import datetime
 
 import pytest
@@ -30,6 +31,8 @@ from custom_components.komfovent.sensor import (
     ConnectedPanelsSensor,
     ControllerFirmwareVersionSensor,
     DutyCycleSensor,
+    DxCoolingSensor,
+    DxHeatingSensor,
     FloatSensor,
     FloatX10Sensor,
     FloatX100Sensor,
@@ -55,6 +58,8 @@ DESC = SensorEntityDescription(key="test", name="Test")
 # (sensor_class, raw, expected, min, max, out_of_range, low_out_of_range)
 VALIDATION_SENSORS = [
     (DutyCycleSensor, 500, 50.0, 0, 1000, 1010, -10),
+    (DxHeatingSensor, 500, 50.0, -1000, 1000, 1010, -1010),
+    (DxCoolingSensor, -500, 50.0, -1000, 1000, 1010, -1010),
     (TemperatureSensor, 215, 21.5, -500, 1200, 1210, -510),
     (RelativeHumiditySensor, 65, 65, 0, 125, 126, None),
     (AbsoluteHumiditySensor, 850, 8.5, 1, 10000, 10001, 0),
@@ -166,7 +171,15 @@ def test_scaling_sensors(mock_coordinator, sensor_class, raw, expected):
 
 
 @pytest.mark.parametrize(
-    "sensor_class", [FloatSensor, FloatX10Sensor, FloatX100Sensor, FloatX1000Sensor]
+    "sensor_class",
+    [
+        FloatSensor,
+        FloatX10Sensor,
+        FloatX100Sensor,
+        FloatX1000Sensor,
+        DxHeatingSensor,
+        DxCoolingSensor,
+    ],
 )
 def test_scaling_sensors_none(mock_coordinator, sensor_class):
     """Test scaling sensors return None when no data."""
@@ -633,3 +646,27 @@ async def test_create_sensors_includes_active_alarms(mock_coordinator):
     sensors = await create_sensors(mock_coordinator)
     keys = {s.entity_description.key for s in sensors}
     assert "active_alarms" in keys
+
+
+@pytest.mark.parametrize(
+    ("sensor_class", "raw"),
+    [(DxHeatingSensor, -500), (DxCoolingSensor, 500), (DxCoolingSensor, 0)],
+)
+def test_dx_opposite_direction_is_zero(mock_coordinator, sensor_class, raw):
+    """Each DX entity reads a positive zero while not running that way."""
+    mock_coordinator.data = {100: raw}
+    value = sensor_class(mock_coordinator, 100, DESC).native_value
+    assert value == 0.0
+    assert math.copysign(1, value) > 0
+
+
+@pytest.mark.parametrize(
+    ("key", "sensor_class"),
+    [("dx_heating", DxHeatingSensor), ("dx_cooling", DxCoolingSensor)],
+)
+async def test_create_sensors_dx(mock_coordinator, key, sensor_class):
+    """Register 916 is exposed as a separate heating and cooling entity."""
+    sensors = await create_sensors(mock_coordinator)
+    sensor = next(s for s in sensors if s.entity_description.key == key)
+    assert isinstance(sensor, sensor_class)
+    assert sensor.register_id == registers.REG_DX_UNIT


### PR DESCRIPTION
Fixes #210

Register 916 (`DX unit`) is a **signed** short, `-1000 - +1000`, x10 % — see the register 916 row in `docs/MODBUS_C6.md`. It is the only signed level register; 913-915 are all unsigned.

`registers.py` already decodes it as int16, but the entity was built on `DutyCycleSensor`, which rejects anything outside 0-100 %. Every cooling reading was discarded and Home Assistant showed `Unknown`, exactly as reported.

## Change

`dx_unit` is replaced by two entities reading the same register:

| Register 916 | DX Heating | DX Cooling |
|-------------:|-----------:|-----------:|
| +500         | 50 %       | 0 %        |
| 0            | 0 %        | 0 %        |
| -500         | 0 %        | 50 %       |

- `DxUnitSensor` validates the signed range once, reusing `MAX_DUTY_CYCLE`
- `DxHeatingSensor` / `DxCoolingSensor` each expose one direction, following the existing `FloatX10Sensor` → `DutyCycleSensor` chaining idiom in the same file
- The idle direction reports `0 %` rather than `Unknown`, so `MEASUREMENT` statistics stay meaningful and history stays continuous
- `DutyCycleSensor` is unchanged and still guards the unsigned registers

Both entities are disabled by default, as `dx_unit` was.

## Tests

Two rows in the existing `VALIDATION_SENSORS` table (reusing its five range checks), two entries in `test_scaling_sensors_none`, plus small parametrized tests for the idle direction and entity creation. `pytest`, `ruff`, `ty` pass; diff coverage 100 %.

## Notes

- **The polarity is inferred, not documented.** The vendor tables give the range and signedness but never say which sign is which; negative = cooling comes from the field report in #210 and from the unit being reversible. Worth confirming against a heating-mode reading before release.
- **No migration.** `dx_unit` is dropped, so anyone who had it enabled gets a stale unavailable entity to delete manually and loses that history. It was disabled by default, so this should be rare.
